### PR TITLE
Add game termination

### DIFF
--- a/inc/blokus.h
+++ b/inc/blokus.h
@@ -74,6 +74,8 @@ typedef struct {
     shape_t sel;
     tile_t *hand[2][SHAPE_Z + 1];
     int score[2];
+    // the linked list that link all the empty positions on the map
+    int empty;
     int next_empty[N_ROW * N_COL];
     int prev_empty[N_ROW * N_COL];
     int map[N_ROW][N_COL];

--- a/inc/blokus.h
+++ b/inc/blokus.h
@@ -81,6 +81,10 @@ typedef struct {
     int map[N_ROW][N_COL];
     char code[16];
     int status;
+    struct {
+        int shape;
+        coord_t pos;
+    } hint;
 } gcb_t;  // game control block
 
 extern const coord_t STARTING_POINT[2];

--- a/src/blokus.c
+++ b/src/blokus.c
@@ -361,9 +361,9 @@ static int decode_tile(tile_t *tile, char *code)
     return 0;
 }
 
-static int test_place(gcb_t *gcb, tile_t *tile)
+static int test_place(gcb_t *gcb, tile_t *tile, int p)
 {
-    int p = gcb->turn, valid = 0;
+    int valid = 0;
     coord_t pos = tile->pos;
 
     // If the player hasn't place any tiles yet
@@ -426,6 +426,14 @@ static int test_place(gcb_t *gcb, tile_t *tile)
     return (valid)? 0 : -1;
 }
 
+int can_place(gcb_t *gcb, int player)
+{
+    // For each hand of player
+    // For each empty map entry
+    // Test place
+    return 0;
+}
+
 gcb_t *init_gcb(int first)
 {
     gcb_t *gcb = malloc(sizeof(gcb_t));
@@ -481,7 +489,7 @@ int is_valid(gcb_t *gcb)
     int p = gcb->turn;
     tile_t *tile;
     tile = gcb->hand[p][gcb->sel];
-    return test_place(gcb, tile) == 0;
+    return test_place(gcb, tile, p) == 0;
 }
 
 int update(gcb_t *gcb, char *code)
@@ -494,7 +502,7 @@ int update(gcb_t *gcb, char *code)
         return -1;
     }
 
-    if (test_place(gcb, tile) < 0)
+    if (test_place(gcb, tile, p) < 0)
         return -1;  // reject invalid update
 
     coord_t pos = tile->pos;

--- a/src/blokus.c
+++ b/src/blokus.c
@@ -431,6 +431,9 @@ int can_place(gcb_t *gcb, int player)
     // For each hand of player
     // For each empty map entry
     // Test place
+    for (int s = SHAPE_M; s <= SHAPE_Z; ++s) {
+        
+    }
     return 0;
 }
 
@@ -450,6 +453,7 @@ gcb_t *init_gcb(int first)
             gcb->map[y][x] = -1;
         }
     }
+    gcb->empty = 0;
     for (int i = 0; i < 195; ++i)
         gcb->next_empty[i] = i + 1;
     gcb->next_empty[195] = -1;
@@ -510,8 +514,19 @@ int update(gcb_t *gcb, char *code)
         int y = pos.y + tile->blks[i].y, x = pos.x + tile->blks[i].x;
         int k = N_ROW * y + x;
         gcb->map[y][x] = p;
-        gcb->next_empty[gcb->prev_empty[k]] = gcb->next_empty[k];
-        gcb->prev_empty[gcb->next_empty[k]] = gcb->prev_empty[k];
+        
+        // point the head of the list to the next of k if k is head
+        if (gcb->empty == k)
+            gcb->empty = gcb->next_empty[k];
+        else
+            gcb->next_empty[gcb->prev_empty[k]] = gcb->next_empty[k];
+
+        // if k is not the tail of the list then update the next of k
+        if (gcb->next_empty[k] != -1)
+            gcb->prev_empty[gcb->next_empty[k]] = gcb->prev_empty[k];
+
+        gcb->next_empty[k] = -1;
+        gcb->prev_empty[k] = -1;
     }
 
     // record the latest update in gcb->code

--- a/src/blokus.c
+++ b/src/blokus.c
@@ -467,6 +467,8 @@ int can_place(gcb_t *gcb, int p)
 recover_tile_and_return_true:
     if (m) mir_tile(tile);
     rot_tile(tile, -90 * r);
+    gcb->hint.pos = tile->pos;
+    gcb->hint.shape = tile->shape;
     return 1;
 }
 

--- a/src/blokus.c
+++ b/src/blokus.c
@@ -496,6 +496,8 @@ gcb_t *init_gcb(int first)
         gcb->prev_empty[i] = i - 1;
     gcb->prev_empty[0] = -1;
     gcb->status = OK;
+    // generate hint on gcb initialization
+    can_place(gcb, first);
     return gcb;
 }
 


### PR DESCRIPTION
- Game can terminate in 3 condition 
  - p0 wins (`EOG_P`)
  - p1 wins (`EOG_Q`)
  - tie (`EOG_T`)
 - Add hint to gcb so that the player to update the gcb can have a hint on where we can place a tile
 - Using linked list to chain all the empty entries on the map so that we don't have to check all 196 entries every time we examine if a player can play or not