### PR TITLE
Add TURN op and add resend timeout

### DIFF
--- a/inc/frame.h
+++ b/inc/frame.h
@@ -12,6 +12,7 @@ enum OPCODE {
     REQ_PAIR,
     PAIRED,
     REQ_TURN,
+    TURN,
     REQ_STATUS,
     RES,
     REQ_PLACE

--- a/inc/sock.h
+++ b/inc/sock.h
@@ -1,6 +1,8 @@
 #ifndef _SOCK_H
 #define _SOCK_H
 
+#define TIMEOUT 10000
+
 int open_clientfd(char *hostname, char *port) __attribute__((unused));
 int open_listenfd(char *port) __attribute__((unused));
 


### PR DESCRIPTION
- I have add the *TURN* opcode to `frame.h`, the opcode is used when server tells which client starts first.
- Resend timeout definition has been added to `sock.h`